### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://pfedev.visualstudio.com/1f76f775-aad6-4301-b290-fa869d89cc66/642abda6-106e-4392-b44e-3070fd2d5dc1/_apis/work/boardbadge/4b89fadc-b1e3-4bf5-af20-48a2a13a160b)](https://pfedev.visualstudio.com/1f76f775-aad6-4301-b290-fa869d89cc66/_boards/board/t/642abda6-106e-4392-b44e-3070fd2d5dc1/Microsoft.RequirementCategory)
 # Func-on-Containers-with-PEP
 
 This sample is meant to illustrate the following.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#661](https://pfedev.visualstudio.com/1f76f775-aad6-4301-b290-fa869d89cc66/_workitems/edit/661). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.